### PR TITLE
feat(Table): add prop to toggle borders

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -39,6 +39,8 @@ export const TableRender = (
     getRowKey,
     rowHoverEffect,
     onScrollToBottom,
+    borderBetweenColumns = true,
+    borderBetweenRows = true,
     ...otherProps
   } = props;
 
@@ -95,6 +97,8 @@ export const TableRender = (
           stickyRightOffsetsAtom={stickyRightOffsetsAtom}
           bordersAtom={bordersFlattenedHeadersAtom}
           tableRef={scrollElementRef}
+          borderBetweenColumns={borderBetweenColumns}
+          borderBetweenRows={borderBetweenRows}
         />
       }
       body={
@@ -112,6 +116,8 @@ export const TableRender = (
           rowHoverEffect={rowHoverEffect}
           leftNoVisibleItemsAtom={leftNoVisibleItemsAtom}
           rightNoVisibleItemsAtom={rightNoVisibleItemsAtom}
+          borderBetweenColumns={borderBetweenColumns}
+          borderBetweenRows={borderBetweenRows}
         />
       }
     />

--- a/src/components/Table/TableData/TableData.tsx
+++ b/src/components/Table/TableData/TableData.tsx
@@ -58,6 +58,8 @@ const TableDataRender = (
     rowHoverEffect,
     leftNoVisibleItemsAtom,
     rightNoVisibleItemsAtom,
+    borderBetweenColumns,
+    borderBetweenRows,
     ...otherProps
   } = props;
 
@@ -88,6 +90,8 @@ const TableDataRender = (
             ref={rowsRefs[rowIndex]}
             leftNoVisibleItemsAtom={leftNoVisibleItemsAtom}
             rightNoVisibleItemsAtom={rightNoVisibleItemsAtom}
+            borderBetweenColumns={borderBetweenColumns}
+            borderBetweenRows={borderBetweenRows}
           />
         );
       })}

--- a/src/components/Table/TableHeader/TableHeader.tsx
+++ b/src/components/Table/TableHeader/TableHeader.tsx
@@ -26,6 +26,8 @@ export const TableHeader: TableHeaderComponent = forwardRef((props, ref) => {
     headerCellsRefsAtom,
     bordersAtom,
     tableRef,
+    borderBetweenColumns,
+    borderBetweenRows,
     ...otherProps
   } = props;
 
@@ -54,9 +56,9 @@ export const TableHeader: TableHeaderComponent = forwardRef((props, ref) => {
             className={cnTableHeader('Cell', { pinned: !!column.pinned }, [
               cnTableCell({
                 separator: column.isSeparator,
-                borderLeft: borders[index][0],
-                borderRight: borders[index][1],
-                borderTop: borders[index][2],
+                borderLeft: borderBetweenColumns ? borders[index][0] : false,
+                borderRight: borderBetweenColumns ? borders[index][1] : false,
+                borderTop: borderBetweenRows ? borders[index][2] : false,
                 sticky: !!column.pinned || stickyHeader,
                 up: !!column.pinned,
               }),

--- a/src/components/Table/TableRow/TableRow.tsx
+++ b/src/components/Table/TableRow/TableRow.tsx
@@ -19,6 +19,8 @@ type TableRowProps = PropsWithHTMLAttributesAndRef<
     tableRef: React.RefObject<HTMLDivElement>;
     leftNoVisibleItemsAtom: AtomMut<number>;
     rightNoVisibleItemsAtom: AtomMut<number>;
+    borderBetweenColumns?: boolean;
+    borderBetweenRows?: boolean;
   },
   HTMLDivElement
 >;
@@ -55,6 +57,8 @@ export const TableRow: TableRowComponent = forwardRef((props, ref) => {
     tableRef,
     leftNoVisibleItemsAtom,
     rightNoVisibleItemsAtom,
+    borderBetweenColumns,
+    borderBetweenRows,
     ...otherProps
   } = props;
   const [lowHeaders] = useAtom(lowHeadersAtom);
@@ -104,13 +108,21 @@ export const TableRow: TableRowComponent = forwardRef((props, ref) => {
       <TableRowCell
         key={cnTableRow('Cell', { key: accessor || columnIndex })}
         borderLeft={
-          columnIndex !== 0 &&
-          !(pinned !== 'left' && lowHeaders[columnIndex - 1]?.pinned === 'left')
+          borderBetweenColumns
+            ? columnIndex !== 0 &&
+              !(
+                pinned !== 'left' &&
+                lowHeaders[columnIndex - 1]?.pinned === 'left'
+              )
+            : false
         }
         borderRight={
-          pinned === 'left' && lowHeaders[columnIndex + 1]?.pinned !== 'left'
+          borderBetweenColumns
+            ? pinned === 'left' &&
+              lowHeaders[columnIndex + 1]?.pinned !== 'left'
+            : false
         }
-        borderTop={!isSeparator && rowIndex !== 0}
+        borderTop={borderBetweenRows ? !isSeparator && rowIndex !== 0 : false}
         ref={columnIndex === 0 ? ref : undefined}
         row={row}
         rowIndex={rowIndex}

--- a/src/components/Table/__stand__/Table.dev.stand.mdx
+++ b/src/components/Table/__stand__/Table.dev.stand.mdx
@@ -155,22 +155,24 @@ type TableRowMouseEvent<ROW> = (
 type GetRowKey<ROW> = (row: ROW) => string | number;
 ```
 
-| Свойство           | Тип                           | По умолчанию      | Описание                                                     |
-| ------------------ | ----------------------------- | ----------------- | ------------------------------------------------------------ |
-| `columns?`         | `TableColumn[]`               | -                 | Колонки                                                      |
-| `rows?`            | `ROW[]`                       | -                 | Строки                                                       |
-| `getRowKey?`       | `GetRowKey<ROW>`              | `(row) => row.id` | Функция получения ключа, если ключ не найден берется `index` |
-| `onRowMouseEnter?` | `TableRowMouseEvent<ROW>`     | -                 | Событие `onMouseEnter` на строке                             |
-| `onRowMouseLeave?` | `TableRowMouseEvent<ROW>`     | -                 | Событие `onMouseLeave` на строке                             |
-| `onRowClick?`      | `TableRowMouseEvent<ROW>`     | -                 | Событие `onClick` на строке                                  |
-| `virtualScroll?`   | `boolean`                     | -                 | Включение виртуальной прокрутки                              |
-| `stickyHeader?`    | `boolean`                     | -                 | Зафиксировать шапку сверху                                   |
-| `resizable?`       | `'inside'` &#124; `'outside'` | -                 | Включение возможности изменять ширину колонок                |
-| `zebraStriped?`    | `boolean`                     | -                 | Окрашивание строк через одну                                 |
-| `headerZIndex?`    | `number`                      | `1`               | `zIndex` шапки                                               |
-| `rowHoverEffect?`  | `boolean`                     | -                 | Включает эффект наведения на строку                          |
-| `className?`       | `string`                      | -                 | Дополнительный CSS-класс                                     |
-| `ref?`             | `React.Ref<HTMLDivElement>`   | -                 | Ссылка на корневой DOM-элемент                               |
+| Свойство             | Тип                           | По умолчанию      | Описание                                                     |
+| -------------------- | ----------------------------- | ----------------- | ------------------------------------------------------------ |
+| `columns?`           | `TableColumn[]`               | -                 | Колонки                                                      |
+| `rows?`              | `ROW[]`                       | -                 | Строки                                                       |
+| `getRowKey?`         | `GetRowKey<ROW>`              | `(row) => row.id` | Функция получения ключа, если ключ не найден берется `index` |
+| `onRowMouseEnter?`   | `TableRowMouseEvent<ROW>`     | -                 | Событие `onMouseEnter` на строке                             |
+| `onRowMouseLeave?`   | `TableRowMouseEvent<ROW>`     | -                 | Событие `onMouseLeave` на строке                             |
+| `onRowClick?`        | `TableRowMouseEvent<ROW>`     | -                 | Событие `onClick` на строке                                  |
+| `virtualScroll?`     | `boolean`                     | -                 | Включение виртуальной прокрутки                              |
+| `stickyHeader?`      | `boolean`                     | -                 | Зафиксировать шапку сверху                                   |
+| `resizable?`         | `'inside'` &#124; `'outside'` | -                 | Включение возможности изменять ширину колонок                |
+| `zebraStriped?`      | `boolean`                     | -                 | Окрашивание строк через одну                                 |
+| `headerZIndex?`      | `number`                      | `1`               | `zIndex` шапки                                               |
+| `rowHoverEffect?`    | `boolean`                     | -                 | Включает эффект наведения на строку                          |
+| `className?`         | `string`                      | -                 | Дополнительный CSS-класс                                     |
+| `ref?`               | `React.Ref<HTMLDivElement>`   | -                 | Ссылка на корневой DOM-элемент                               |
+| `borderBetweenColumns?` | `boolean`                     | true              | Отображение границ между колонками                           |
+| `borderBetweenRows?`    | `boolean`                     | true              | Отображение границ между строками                            |
 
 ## Колонка
 
@@ -2041,7 +2043,7 @@ export const TableExampleRenderRow = () => {
 
 ## Состояние загрузки
 
-Загрузку можно отобразить двумя видами с помощью `Loader` или `Skeleton.
+Загрузку можно отобразить двумя видами с помощью `Loader` или `Skeleton`.
 
 **Пример загрузки данных всей таблицы с помощью `Loader`:**
 

--- a/src/components/Table/__stand__/Table.variants.tsx
+++ b/src/components/Table/__stand__/Table.variants.tsx
@@ -136,6 +136,8 @@ const Variants = () => {
   const resizable = useSelect('resizable', ['outside', 'inside']);
   const withRenderCell = useBoolean('withRenderCell');
   const withRenderHeaderCell = useBoolean('withRenderHeaderCell');
+  const borderBetweenColumns = useBoolean('borderBetweenColumns', true);
+  const borderBetweenRows = useBoolean('borderBetweenRows', true);
 
   const virtualScrollProp = virtualScroll
     ? virtualScrollMap[virtualScroll]
@@ -328,6 +330,8 @@ const Variants = () => {
         stickyHeader={stickyHeader}
         virtualScroll={virtualScrollProp}
         style={{ maxHeight: '100%' }}
+        borderBetweenColumns={borderBetweenColumns}
+        borderBetweenRows={borderBetweenRows}
       />
     </div>
   );

--- a/src/components/Table/types.ts
+++ b/src/components/Table/types.ts
@@ -90,6 +90,8 @@ export type TableProps<ROW = TableDefaultRow> = PropsWithHTMLAttributesAndRef<
     headerZIndex?: number;
     rowHoverEffect?: boolean;
     onScrollToBottom?: (length: number) => void;
+    borderBetweenColumns?: boolean;
+    borderBetweenRows?: boolean;
   },
   HTMLDivElement
 >;
@@ -108,6 +110,8 @@ export type TableHeaderProps<ROW = TableDefaultRow> =
       headerCellsRefsAtom: AtomMut<React.RefObject<HTMLDivElement>[]>;
       bordersAtom: AtomMut<[boolean, boolean, boolean][]>;
       tableRef: React.RefObject<HTMLDivElement>;
+      borderBetweenColumns?: boolean;
+      borderBetweenRows?: boolean;
     },
     HTMLDivElement
   >;
@@ -169,6 +173,8 @@ export type TableDataProps<ROW = TableDefaultRow> =
       rowHoverEffect?: boolean;
       leftNoVisibleItemsAtom: AtomMut<number>;
       rightNoVisibleItemsAtom: AtomMut<number>;
+      borderBetweenColumns?: boolean;
+      borderBetweenRows?: boolean;
     },
     HTMLDivElement
   > & {


### PR DESCRIPTION
## Описание изменений
closes https://github.com/consta-design-system/uikit/issues/3963. Добавил пропы `borderBetweenRows` `borderBetweenColumns` как и в старой таблице с переключением бордеров. Дефолтное значение=true - не уверен возможно нужно сделать false как и в старой таблице?

## Чек-лист

- [ ] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [ ] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] PR: есть описание изменений
- [ ] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются [переменные](../src/components/Theme)
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [ ] Коммиты: проименованы в соответствии с [правилами](https://consta-uikit.vercel.app/?path=/docs/common-develop-commits-style--page)
